### PR TITLE
Fix bug of re-adding deleted handle

### DIFF
--- a/DocumentStore.application
+++ b/DocumentStore.application
@@ -1,0 +1,3 @@
+#jarvis-config
+application-name:DocumentStore
+base-server-address:http://localhost:55555

--- a/src/Jarvis.DocumentStore.Core/CommandHandlers/DocumentHandlers/LinkHandleToDocumentCommandHandler.cs
+++ b/src/Jarvis.DocumentStore.Core/CommandHandlers/DocumentHandlers/LinkHandleToDocumentCommandHandler.cs
@@ -25,7 +25,9 @@ namespace Jarvis.DocumentStore.Core.CommandHandlers.DocumentHandlers
                 handleId,
                 h =>
                 {
-                    if (!h.HasBeenCreated) h.Initialize(handleId, cmd.HandleInfo.Handle);
+                    //Call Intialize on the handle
+                    h.Initialize(cmd.HandleInfo.Handle);
+
                     h.SetFileName(cmd.HandleInfo.FileName);
                     h.SetCustomData(cmd.HandleInfo.CustomData);
                     h.Link(cmd.DocumentDescriptorId);

--- a/src/Jarvis.DocumentStore.Core/Domain/Document/Document.cs
+++ b/src/Jarvis.DocumentStore.Core/Domain/Document/Document.cs
@@ -15,12 +15,21 @@ namespace Jarvis.DocumentStore.Core.Domain.Document
         {
         }
 
-        public void Initialize(DocumentId id, DocumentHandle handle)
+        public void Initialize(DocumentHandle handle)
         {
-
-            ThrowIfDeleted();
-
-            RaiseEvent(new DocumentInitialized(handle));
+            if (!HasBeenCreated)
+            {
+                RaiseEvent(new DocumentInitialized(handle, false));
+            }
+            else if (InternalState.HasBeenDeleted)
+            {
+                RaiseEvent(new DocumentInitialized(handle, true));
+            }
+            else
+            {
+                if (handle != InternalState.Handle)
+                    throw new DomainException(Id, "Trying to initialize an initialized handle with different handle");
+            }
         }
 
         public void Link(DocumentDescriptorId documentId)

--- a/src/Jarvis.DocumentStore.Core/Domain/Document/DocumentState.cs
+++ b/src/Jarvis.DocumentStore.Core/Domain/Document/DocumentState.cs
@@ -21,6 +21,8 @@ namespace Jarvis.DocumentStore.Core.Domain.Document
         void When(DocumentInitialized e)
         {
             this.Handle = e.Handle;
+            if (e.ReInit)
+                this.HasBeenDeleted = false;
         }
 
         void When(DocumentDeleted e)

--- a/src/Jarvis.DocumentStore.Core/Domain/Document/Events/DocumentInitialized.cs
+++ b/src/Jarvis.DocumentStore.Core/Domain/Document/Events/DocumentInitialized.cs
@@ -1,5 +1,6 @@
 using Jarvis.DocumentStore.Core.Model;
 using Jarvis.Framework.Shared.Events;
+using System;
 
 namespace Jarvis.DocumentStore.Core.Domain.Document.Events
 {
@@ -8,9 +9,16 @@ namespace Jarvis.DocumentStore.Core.Domain.Document.Events
 
         public DocumentHandle Handle { get; private set; }
 
-        public DocumentInitialized( DocumentHandle handle)
-        {
+        /// <summary>
+        /// True if the handle was deleted, then re-inited because it was resinserted
+        /// into the system
+        /// </summary>
+        public Boolean ReInit { get; private set; }
 
+
+        public DocumentInitialized( DocumentHandle handle, Boolean reinit)
+        {
+            ReInit = reinit;
             Handle = handle;
         }
 

--- a/src/Jarvis.DocumentStore.Host/Jarvis.DocumentStore.Host.csproj
+++ b/src/Jarvis.DocumentStore.Host/Jarvis.DocumentStore.Host.csproj
@@ -59,9 +59,9 @@
     <Reference Include="Common.Logging">
       <HintPath>..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Jarvis.ConfigurationService.Client, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Jarvis.ConfigurationService.Client, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Jarvis.ConfigurationService.Client.1.1.94\lib\NET45\Jarvis.ConfigurationService.Client.dll</HintPath>
+      <HintPath>..\packages\Jarvis.ConfigurationService.Client.1.1.124\lib\NET45\Jarvis.ConfigurationService.Client.dll</HintPath>
     </Reference>
     <Reference Include="Jarvis.Framework.MongoAppender, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Jarvis.DocumentStore.Host/packages.config
+++ b/src/Jarvis.DocumentStore.Host/packages.config
@@ -5,7 +5,7 @@
   <package id="Castle.LoggingFacility" version="3.3.0" targetFramework="net45" />
   <package id="Castle.Windsor" version="3.3.0" targetFramework="net45" />
   <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
-  <package id="Jarvis.ConfigurationService.Client" version="1.1.94" targetFramework="net45" />
+  <package id="Jarvis.ConfigurationService.Client" version="1.1.124" targetFramework="net45" />
   <package id="Jarvis.Framework.MongoAppender" version="1.1.19" targetFramework="net45" />
   <package id="Jarvis.Framework.UdpAppender" version="1.0.9" targetFramework="net45" />
   <package id="log4net" version="1.2.10" targetFramework="net45" />

--- a/src/Jarvis.DocumentStore.Tests/GlobalSetupFixture.cs
+++ b/src/Jarvis.DocumentStore.Tests/GlobalSetupFixture.cs
@@ -41,7 +41,7 @@ namespace Jarvis.DocumentStore.Tests
                 mngr.RegisterIdentitiesFromAssembly(typeof (QueuedJobId).Assembly);
 
                 EventStoreIdentityBsonSerializer.IdentityConverter = mngr;
-                MongoFlatMapper.EnableFlatMapping();
+                Jarvis.DocumentStore.Host.Support.MongoFlatMapper.EnableFlatMapping();
             }
             catch (ReflectionTypeLoadException rle)
             {

--- a/src/Jarvis.DocumentStore.Tests/ProjectionTests/StreamProjectionTest.cs
+++ b/src/Jarvis.DocumentStore.Tests/ProjectionTests/StreamProjectionTest.cs
@@ -116,7 +116,7 @@ namespace Jarvis.DocumentStore.Tests.ProjectionTests
         public void verify_document_descriptor_initialized_not_generates_record()
         {
             CreateSut();
-            var evt = new DocumentInitialized(new DocumentHandle("rev_1")).AssignIdForTest(new DocumentId(1));
+            var evt = new DocumentInitialized(new DocumentHandle("rev_1"), false).AssignIdForTest(new DocumentId(1));
             _sut.Handle(evt, false);
             Assert.That(rmStream, Has.Count.EqualTo(0), "Document Initialized is raised when document descriptor still is not de-duplicated.");
         }

--- a/src/Jarvis.DocumentStore.Tests/SelfHostIntegratonTests/DocumentControllerIntegrationTests.cs
+++ b/src/Jarvis.DocumentStore.Tests/SelfHostIntegratonTests/DocumentControllerIntegrationTests.cs
@@ -598,6 +598,63 @@ namespace Jarvis.DocumentStore.Tests.SelfHostIntegratonTests
         }
 
         [Test]
+        public async void verify_de_duplication_not_link_to_deleted_handles()
+        {
+            await _documentStoreClient.UploadAsync(TestConfig.PathToDocumentPdf, new DocumentHandle("handleA"));
+            await UpdateAndWaitAsync();
+
+            await _documentStoreClient.DeleteAsync(new DocumentHandle("handleA"));
+            await UpdateAndWaitAsync();
+
+            //re-add same payload with same handle
+            await _documentStoreClient.UploadAsync(TestConfig.PathToDocumentPdf, new DocumentHandle("handleB"));
+            await UpdateAndWaitAsync();
+
+            //verify that everything is ok.
+            var allDescriptor =  _documentDescriptorCollection.FindAll().ToList();
+            Assert.That(allDescriptor, Has.Count.EqualTo(1));
+            Assert.That(allDescriptor[0].Documents, Is.EquivalentTo(new[] { new Core.Model.DocumentHandle("handleB") }));
+        }
+
+        [Test]
+        public async void verify_de_duplication_not_link_to_deleted_handles_same_handle()
+        {
+            await _documentStoreClient.UploadAsync(TestConfig.PathToDocumentPdf, new DocumentHandle("handleA"));
+            await UpdateAndWaitAsync();
+
+            await _documentStoreClient.DeleteAsync(new DocumentHandle("handleA"));
+            await UpdateAndWaitAsync();
+
+            //re-add same payload with same handle
+            await _documentStoreClient.UploadAsync(TestConfig.PathToDocumentPdf, new DocumentHandle("handleA"));
+            await UpdateAndWaitAsync();
+
+            //verify that everything is ok.
+            var allDescriptor =  _documentDescriptorCollection.FindAll().ToList();
+            Assert.That(allDescriptor, Has.Count.EqualTo(1));
+            Assert.That(allDescriptor[0].Documents, Is.EquivalentTo(new[] { new Core.Model.DocumentHandle("handleA") }));
+        }
+
+        [Test]
+        public async void verify_delete_then_re_add_handle()
+        {
+            await _documentStoreClient.UploadAsync(TestConfig.PathToDocumentPdf, new DocumentHandle("handleA"));
+            await UpdateAndWaitAsync();
+
+            await _documentStoreClient.DeleteAsync(new DocumentHandle("handleA"));
+            await UpdateAndWaitAsync();
+
+            //re-add same payload with same handle
+            await _documentStoreClient.UploadAsync(TestConfig.PathToDocumentPng, new DocumentHandle("handleA"));
+            await UpdateAndWaitAsync();
+
+            //verify that everything is ok.
+            var allDescriptor = _documentDescriptorCollection.FindAll().ToList();
+            Assert.That(allDescriptor, Has.Count.EqualTo(1));
+            Assert.That(allDescriptor[0].Documents, Is.EquivalentTo(new[] { new Core.Model.DocumentHandle("handleA") }));
+        }
+
+        [Test]
         public async void attachments_not_retrieve_nested_attachment()
         {
             //Upload father


### PR DESCRIPTION
https://trello.com/c/oo9Cp7ip/404-bug-documentstore-projection-che-crasha

Ho supportato da parte dell'oggetto di dominio Document la possibilità di avere il metodo Initialize chiamato anche quando l'handle è cancellato. In quel caso viene generato un evento di HandleInitialized con un boolean che indica una re-init.

In questo modo evitiamo i bug di reinizializzazione che crashano completamente il DS.