### PR TITLE
WebClient helper methods to detect correct enconding - #10488

### DIFF
--- a/src/Jarvis.DocumentStore.Client/DocumentStoreServiceClient.cs
+++ b/src/Jarvis.DocumentStore.Client/DocumentStoreServiceClient.cs
@@ -13,6 +13,7 @@ using Jarvis.DocumentStore.Shared.Serialization;
 using Newtonsoft.Json;
 using Jarvis.DocumentStore.Shared.Jobs;
 using Newtonsoft.Json.Linq;
+using Jarvis.DocumentStore.Shared.Helpers;
 
 #if DisablePriLongPath || NETSTANDARD
 using Path = System.IO.Path;
@@ -262,7 +263,7 @@ namespace Jarvis.DocumentStore.Client
             using (var client = new WebClient())
             {
                 var resourceUri = new Uri(_documentStoreUri, Tenant + "/documents/" + originalHandle + "/copy/" + copiedHandle);
-                return client.DownloadString(resourceUri);
+                return client.DownloadStringAwareOfEncoding(resourceUri);
             }
         }
 
@@ -689,7 +690,7 @@ namespace Jarvis.DocumentStore.Client
             using (var client = new WebClient())
             {
                 Uri endPoint = GenerateUriForFeed(startFeed, numOfFeeds, types);
-                var json = client.DownloadString(endPoint);
+                var json = client.DownloadStringAwareOfEncoding(endPoint);
                 return FromJson<IEnumerable<ClientFeed>>(json);
             }
         }
@@ -699,7 +700,7 @@ namespace Jarvis.DocumentStore.Client
             var getJobsUri = GenerateUriForGetJobs(handle);
             using (var client = new WebClient())
             {
-                var result = await client.DownloadStringTaskAsync(getJobsUri).ConfigureAwait(false);
+                var result = await client.DownloadStringAwareOfEncodingAsync(getJobsUri).ConfigureAwait(false);
                 return GenerateArrayOfJobs(result);
             }
         }
@@ -709,7 +710,7 @@ namespace Jarvis.DocumentStore.Client
             var getJobsUri = GenerateUriForGetJobs(handle);
             using (var client = new WebClient())
             {
-                var result = client.DownloadString(getJobsUri);
+                var result = client.DownloadStringAwareOfEncoding(getJobsUri);
                 return GenerateArrayOfJobs(result);
             }
         }
@@ -724,7 +725,7 @@ namespace Jarvis.DocumentStore.Client
             {
                 ComposeDocumentsModel parameter = CreateParameterForComposeDocuments(resultingDocumentHandle, resultingDocumentFileName, documentList);
                 client.Headers[HttpRequestHeader.ContentType] = "application/json";
-                var result = await client.UploadStringTaskAsync(composePdfUri, JsonConvert.SerializeObject(parameter)).ConfigureAwait(false);
+                var result = await client.UploadStringAwareOfEncodingAsync(composePdfUri, JsonConvert.SerializeObject(parameter)).ConfigureAwait(false);
                 return CreateReturnObjectForComposeDocuments(result);
             }
         }
@@ -739,7 +740,7 @@ namespace Jarvis.DocumentStore.Client
             {
                 ComposeDocumentsModel parameter = CreateParameterForComposeDocuments(resultingDocumentHandle, resultingDocumentFileName, documentList);
                 client.Headers[HttpRequestHeader.ContentType] = "application/json";
-                var result = client.UploadString(composePdfUri, JsonConvert.SerializeObject(parameter));
+                var result = client.UploadStringAwareOfEncoding(composePdfUri, JsonConvert.SerializeObject(parameter));
                 return CreateReturnObjectForComposeDocuments(result);
             }
         }

--- a/src/Jarvis.DocumentStore.JobsHost/Helpers/AbstractOutOfProcessPollerJob.cs
+++ b/src/Jarvis.DocumentStore.JobsHost/Helpers/AbstractOutOfProcessPollerJob.cs
@@ -2,6 +2,7 @@
 using Jarvis.DocumentStore.Client;
 using Jarvis.DocumentStore.Client.Model;
 using Jarvis.DocumentStore.JobsHost.Support;
+using Jarvis.DocumentStore.Shared.Helpers;
 using Jarvis.DocumentStore.Shared.Jobs;
 using Newtonsoft.Json;
 using System;
@@ -352,7 +353,7 @@ namespace Jarvis.DocumentStore.JobsHost.Helpers
                 });
                 Logger.DebugFormat("SetJobExecuted url: {0} with payload {1}", firstUrl.SetJobCompleted, payload);
                 client.Headers[HttpRequestHeader.ContentType] = "application/json";
-                pollerResult = client.UploadString(firstUrl.SetJobCompleted, payload);
+                pollerResult = client.UploadStringAwareOfEncoding(firstUrl.SetJobCompleted, payload);
                 Logger.DebugFormat("SetJobExecuted Result: {0}", pollerResult);
             }
         }
@@ -375,7 +376,7 @@ namespace Jarvis.DocumentStore.JobsHost.Helpers
                 });
                 Logger.DebugFormat("ReQueuedJob url: {0} with payload {1}", firstUrl.SetJobCompleted, payload);
                 client.Headers[HttpRequestHeader.ContentType] = "application/json";
-                pollerResult = client.UploadString(firstUrl.SetJobCompleted, payload);
+                pollerResult = client.UploadStringAwareOfEncoding(firstUrl.SetJobCompleted, payload);
                 Logger.DebugFormat("SetJobExecuted Result: {0}", pollerResult);
             }
         }
@@ -423,7 +424,7 @@ namespace Jarvis.DocumentStore.JobsHost.Helpers
                     });
                     Logger.DebugFormat("Polling url: {0} with payload {1}", firstUrl, payload);
                     client.Headers[HttpRequestHeader.ContentType] = "application/json";
-                    pollerResult = client.UploadString(firstUrl.GetNextJobUrl, payload);
+                    pollerResult = client.UploadStringAwareOfEncoding(firstUrl.GetNextJobUrl, payload);
                     Logger.DebugFormat("GetNextJobResult: {0}", pollerResult);
                 }
                 if (!pollerResult.Equals("null", StringComparison.OrdinalIgnoreCase))
@@ -561,7 +562,7 @@ namespace Jarvis.DocumentStore.JobsHost.Helpers
             {
                 //TODO: use round robin if a document store is down.
                 var url = GetBlobUriForJobFormats(tenantId, jobId);
-                var result = client.DownloadString(url);
+                var result = client.DownloadStringAwareOfEncoding(url);
                 return JsonConvert.DeserializeObject<String[]>(result);
             }
         }

--- a/src/Jarvis.DocumentStore.Shared/Helpers/WebClientExtensions.cs
+++ b/src/Jarvis.DocumentStore.Shared/Helpers/WebClientExtensions.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.Net;
+using System.Net.Mime;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jarvis.DocumentStore.Shared.Helpers
+{
+    /// <summary>
+    /// Useful WebClient extensions methods to be able to correctly work with UTF-8
+    /// </summary>
+    public static class WebClientExtensions
+    {
+        public static string DownloadStringAwareOfEncoding(this WebClient webClient, string uri)
+        {
+            var rawData = webClient.DownloadData(uri);
+            var encoding = GetEncodingFrom(webClient.ResponseHeaders, Encoding.UTF8);
+            return encoding.GetString(rawData);
+        }
+
+        public static string DownloadStringAwareOfEncoding(this WebClient webClient, Uri uri)
+        {
+            var rawData = webClient.DownloadData(uri);
+            var encoding = GetEncodingFrom(webClient.ResponseHeaders, Encoding.UTF8);
+            return encoding.GetString(rawData);
+        }
+
+        public static string UploadStringAwareOfEncoding(this WebClient webClient, string uri, string payload, string method = "POST")
+        {
+            webClient.Encoding = Encoding.UTF8;
+            var uploadData = Encoding.UTF8.GetBytes(payload);
+            var rawData = webClient.UploadData(uri, method, uploadData);
+            var encoding = GetEncodingFrom(webClient.ResponseHeaders, Encoding.UTF8);
+            return encoding.GetString(rawData);
+        }
+
+        public static string UploadStringAwareOfEncoding(this WebClient webClient, Uri uri, string payload, string method = "POST")
+        {
+            webClient.Encoding = Encoding.UTF8;
+            var uploadData = Encoding.UTF8.GetBytes(payload);
+            var rawData = webClient.UploadData(uri, method, uploadData);
+            var encoding = GetEncodingFrom(webClient.ResponseHeaders, Encoding.UTF8);
+            return encoding.GetString(rawData);
+        }
+
+        public static async Task<string> DownloadStringAwareOfEncodingAsync(this WebClient webClient, string uri)
+        {
+            var rawData = await webClient.DownloadDataTaskAsync(uri).ConfigureAwait(false);
+            var encoding = GetEncodingFrom(webClient.ResponseHeaders, Encoding.UTF8);
+            return encoding.GetString(rawData);
+        }
+
+        public static async Task<string> DownloadStringAwareOfEncodingAsync(this WebClient webClient, Uri uri)
+        {
+            var rawData = await webClient.DownloadDataTaskAsync(uri).ConfigureAwait(false);
+            var encoding = GetEncodingFrom(webClient.ResponseHeaders, Encoding.UTF8);
+            return encoding.GetString(rawData);
+        }
+
+        public static async Task<string> UploadStringAwareOfEncodingAsync(this WebClient webClient, string uri, string payload, string method = "POST")
+        {
+            webClient.Encoding = Encoding.UTF8;
+            var uploadData = Encoding.UTF8.GetBytes(payload);
+            var rawData = await webClient.UploadDataTaskAsync(uri, method, uploadData).ConfigureAwait(false);
+            var encoding = GetEncodingFrom(webClient.ResponseHeaders, Encoding.UTF8);
+            return encoding.GetString(rawData);
+        }
+
+        public static async Task<string> UploadStringAwareOfEncodingAsync(this WebClient webClient, Uri uri, string payload, string method = "POST")
+        {
+            webClient.Encoding = Encoding.UTF8;
+            var uploadData = Encoding.UTF8.GetBytes(payload);
+            var rawData = await webClient.UploadDataTaskAsync(uri, method, uploadData).ConfigureAwait(false);
+            var encoding = GetEncodingFrom(webClient.ResponseHeaders, Encoding.UTF8);
+            return encoding.GetString(rawData);
+        }
+
+        public static Encoding GetEncodingFrom(
+            NameValueCollection responseHeaders,
+            Encoding defaultEncoding = null)
+        {
+            try
+            {
+                if (responseHeaders == null)
+                {
+                    return defaultEncoding; // Safe
+                }
+
+                var contentType = responseHeaders["Content-Type"];
+                if (contentType == null)
+                {
+                    return defaultEncoding;
+                }
+
+                var contentTypeParsed = new ContentType(contentType);
+                if (!String.IsNullOrEmpty(contentTypeParsed.CharSet))
+                {
+                    return Encoding.GetEncoding(contentTypeParsed.CharSet);
+                }
+
+                return defaultEncoding;
+
+            }
+            catch (ArgumentException)
+            {
+                // Ignore all argument errors and return the default encoding
+                return defaultEncoding;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Instead of directly using the WebClient `DownloadString` and `UploadString` methods, we now use helper methods that detect the correct encoding to avoid issues with UTF-8.